### PR TITLE
rewrite numbered params to positional params

### DIFF
--- a/examples/kotlin/src/main/kotlin/com/example/booktest/postgresql/QueriesImpl.kt
+++ b/examples/kotlin/src/main/kotlin/com/example/booktest/postgresql/QueriesImpl.kt
@@ -109,8 +109,8 @@ WHERE book_id = ?
 data class UpdateBookISBNParams (
   val title: String,
   val tags: List<String>,
-  val bookId: Int,
-  val isbn: String
+  val isbn: String,
+  val bookId: Int
 )
 
 class QueriesImpl(private val conn: Connection) {
@@ -282,8 +282,8 @@ class QueriesImpl(private val conn: Connection) {
     val stmt = conn.prepareStatement(updateBookISBN)
     stmt.setString(1, arg.title)
     stmt.setArray(2, conn.createArrayOf("pg_catalog.varchar", arg.tags.toTypedArray()))
-    stmt.setInt(3, arg.bookId)
-    stmt.setString(4, arg.isbn)
+    stmt.setString(3, arg.isbn)
+    stmt.setInt(4, arg.bookId)
 
     stmt.execute()
     stmt.close()

--- a/examples/kotlin/src/main/kotlin/com/example/ondeck/QueriesImpl.kt
+++ b/examples/kotlin/src/main/kotlin/com/example/ondeck/QueriesImpl.kt
@@ -96,8 +96,8 @@ WHERE slug = ?
 """
 
 data class UpdateCityNameParams (
-  val slug: String,
-  val name: String
+  val name: String,
+  val slug: String
 )
 
 const val updateVenueName = """-- name: updateVenueName :one
@@ -108,8 +108,8 @@ RETURNING id
 """
 
 data class UpdateVenueNameParams (
-  val slug: String,
-  val name: String
+  val name: String,
+  val slug: String
 )
 
 const val venueCountByCity = """-- name: venueCountByCity :many
@@ -180,6 +180,7 @@ class QueriesImpl(private val conn: Connection) : Queries {
   override fun deleteVenue(slug: String) {
     val stmt = conn.prepareStatement(deleteVenue)
     stmt.setString(1, slug)
+    stmt.setString(2, slug)
 
     stmt.execute()
     stmt.close()
@@ -278,8 +279,8 @@ class QueriesImpl(private val conn: Connection) : Queries {
   @Throws(SQLException::class)
   override fun updateCityName(arg: UpdateCityNameParams) {
     val stmt = conn.prepareStatement(updateCityName)
-    stmt.setString(1, arg.slug)
-    stmt.setString(2, arg.name)
+    stmt.setString(1, arg.name)
+    stmt.setString(2, arg.slug)
 
     stmt.execute()
     stmt.close()
@@ -288,8 +289,8 @@ class QueriesImpl(private val conn: Connection) : Queries {
   @Throws(SQLException::class)
   override fun updateVenueName(arg: UpdateVenueNameParams): Int {
     val stmt = conn.prepareStatement(updateVenueName)
-    stmt.setString(1, arg.slug)
-    stmt.setString(2, arg.name)
+    stmt.setString(1, arg.name)
+    stmt.setString(2, arg.slug)
 
     return stmt.executeQuery().use { results ->
       if (!results.next()) {

--- a/examples/kotlin/src/test/kotlin/com/example/booktest/postgresql/QueriesImplTest.kt
+++ b/examples/kotlin/src/test/kotlin/com/example/booktest/postgresql/QueriesImplTest.kt
@@ -81,14 +81,14 @@ class QueriesImplTest {
 
         // ISBN update fails because parameters are not in sequential order. After changing $N to ?, ordering is lost,
         // and the parameters are filled into the wrong slots.
-//        db.updateBookISBN(
-//            UpdateBookISBNParams(
-//                bookId = b3.bookId,
-//                isbn = "NEW ISBN",
-//                title = "never ever gonna finish, a quatrain",
-//                tags = listOf("someother")
-//            )
-//        )
+        db.updateBookISBN(
+            UpdateBookISBNParams(
+                bookId = b3.bookId,
+                isbn = "NEW ISBN",
+                title = "never ever gonna finish, a quatrain",
+                tags = listOf("someother")
+            )
+        )
 
         val books0 = db.booksByTitleYear(BooksByTitleYearParams("my book title", 2016))
 

--- a/examples/kotlin/src/test/kotlin/com/example/ondeck/QueriesImplTest.kt
+++ b/examples/kotlin/src/test/kotlin/com/example/ondeck/QueriesImplTest.kt
@@ -43,9 +43,10 @@ class QueriesImplTest {
         assertEquals(listOf(city), q.listCities())
         assertEquals(listOf(venue), q.listVenues(city.slug))
 
-        // These updates fail because parameters are not in sequential order. After changing $N to ?, ordering is lost,
-        // and the parameters are filled into the wrong slots.
-//        q.updateCityName(UpdateCityNameParams(slug = city.slug, name = "SF"))
-//        q.updateVenueName(UpdateVenueNameParams(slug = venue.slug, name = "Fillmore"))
+        q.updateCityName(UpdateCityNameParams(slug = city.slug, name = "SF"))
+        val id = q.updateVenueName(UpdateVenueNameParams(slug = venue.slug, name = "Fillmore"))
+        assertEquals(venue.id, id)
+
+        q.deleteVenue(venue.slug)
     }
 }

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -59,6 +59,8 @@ type PackageSettings struct {
 	EmitJSONTags        bool       `json:"emit_json_tags"`
 	EmitPreparedQueries bool       `json:"emit_prepared_queries"`
 	Overrides           []Override `json:"overrides"`
+	// HACK: this is only set in tests, only here till Kotlin support can be merged.
+	rewriteParams       bool
 }
 
 type Override struct {

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -208,6 +208,8 @@ func ParseConfig(rd io.Reader) (GenerateSettings, error) {
 		}
 		if config.Packages[j].Language == "" {
 			config.Packages[j].Language = LanguageGo
+		} else if config.Packages[j].Language == "kotlin" {
+			config.Packages[j].rewriteParams = true
 		}
 	}
 	return config, nil

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -719,6 +719,11 @@ func (r Result) goInnerType(col core.Column, settings CombinedSettings) string {
 	}
 }
 
+type goColumn struct {
+	id int
+	core.Column
+}
+
 // It's possible that this method will generate duplicate JSON tag values
 //
 //   Columns: count, count,   count_2
@@ -726,21 +731,31 @@ func (r Result) goInnerType(col core.Column, settings CombinedSettings) string {
 // JSON tags: count, count_2, count_2
 //
 // This is unlikely to happen, so don't fix it yet
-func (r Result) columnsToStruct(name string, columns []core.Column, settings CombinedSettings) *GoStruct {
+func (r Result) columnsToStruct(name string, columns []goColumn, settings CombinedSettings) *GoStruct {
 	gs := GoStruct{
 		Name: name,
 	}
 	seen := map[string]int{}
+	suffixes := map[int]int{}
 	for i, c := range columns {
 		tagName := c.Name
-		fieldName := StructName(columnName(c, i), settings)
-		if v := seen[c.Name]; v > 0 {
-			tagName = fmt.Sprintf("%s_%d", tagName, v+1)
-			fieldName = fmt.Sprintf("%s_%d", fieldName, v+1)
+		fieldName := StructName(columnName(c.Column, i), settings)
+		// Track suffixes by the ID of the column, so that columns referring to the same numbered parameter can be
+		// reused.
+		suffix := 0
+		if o, ok := suffixes[c.id]; ok {
+			suffix = o
+		} else if v := seen[c.Name]; v > 0 {
+			suffix = v+1
+		}
+		suffixes[c.id] = suffix
+		if suffix > 0 {
+			tagName = fmt.Sprintf("%s_%d", tagName, suffix)
+			fieldName = fmt.Sprintf("%s_%d", fieldName, suffix)
 		}
 		gs.Fields = append(gs.Fields, GoField{
 			Name: fieldName,
-			Type: r.goType(c, settings),
+			Type: r.goType(c.Column, settings),
 			Tags: map[string]string{"json:": tagName},
 		})
 		seen[c.Name]++
@@ -815,9 +830,12 @@ func (r Result) GoQueries(settings CombinedSettings) []GoQuery {
 				Typ:  r.goType(p.Column, settings),
 			}
 		} else if len(query.Params) > 1 {
-			var cols []core.Column
+			var cols []goColumn
 			for _, p := range query.Params {
-				cols = append(cols, p.Column)
+				cols = append(cols, goColumn{
+					id:     p.Number,
+					Column: p.Column,
+				})
 			}
 			gq.Arg = GoQueryValue{
 				Emit:   true,
@@ -858,7 +876,14 @@ func (r Result) GoQueries(settings CombinedSettings) []GoQuery {
 			}
 
 			if gs == nil {
-				gs = r.columnsToStruct(gq.MethodName+"Row", query.Columns, settings)
+				var columns []goColumn
+				for i, c := range query.Columns {
+					columns = append(columns, goColumn{
+						id:     i,
+						Column: c,
+					})
+				}
+				gs = r.columnsToStruct(gq.MethodName+"Row", columns, settings)
 				emit = true
 			}
 			gq.Ret = GoQueryValue{

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -21,7 +21,7 @@ func parseSQL(in string) (Query, error) {
 		return Query{}, err
 	}
 
-	q, err := parseQuery(c, tree.Statements[len(tree.Statements)-1], in)
+	q, err := parseQuery(c, tree.Statements[len(tree.Statements)-1], in, false)
 	if q == nil {
 		return Query{}, err
 	}


### PR DESCRIPTION
JDBC seems to only support positional parameters like `?`. I had to write a HACK to convert numbered parameters like `$1` to `?`. This is buggy and terrible. It also means that you can't use `$1` multiple times in the same query to reference the same value.

This is a better change that examines the AST and edits the parser in the parsing step.

The Kotlin generation has a few extra nuances. The number of parameters no longer directly corresponds to the number of columns in the struct (data class) generated, since numbered parameters can be used multiple times. I work around it here by adding a new `JDBCParamBindings` field to `KtQueryValues` that contains the full list of bindings that need to be passed to the driver. The existing `KtQueryValues.Fields` is used to generate the struct.